### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @items = Item.order("created_at DESC")
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
+    @items = Item.order("created_at DESC")
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,7 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
 
-  # 次に実装 has_one :purchase_record
+  has_one :purchase_record
   belongs_to :user
   has_one_attached :item_image
 

--- a/app/models/purchase_record.rb
+++ b/app/models/purchase_record.rb
@@ -1,0 +1,2 @@
+class PurchaseRecord < ApplicationRecord
+end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,25 +128,27 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      
+      <% if @items.present? %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.item_image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
+          <% if item.purchase_record.present? %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+          <% end %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.feeOption.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,10 +157,9 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>      
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,8 +177,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+    <% end%>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/db/migrate/20231020210947_create_purchase_records.rb
+++ b/db/migrate/20231020210947_create_purchase_records.rb
@@ -1,0 +1,10 @@
+class CreatePurchaseRecords < ActiveRecord::Migration[7.0]
+  def change
+    create_table :purchase_records do |t|
+      t.references  :user,  null: false, foreign_key: true
+      t.references  :item,  null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_09_055759) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_20_210947) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -54,6 +54,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_09_055759) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "purchase_records", charset: "utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_purchase_records_on_item_id"
+    t.index ["user_id"], name: "index_purchase_records_on_user_id"
+  end
+
   create_table "users", charset: "utf8", force: :cascade do |t|
     t.string "nickname", null: false
     t.string "email", default: "", null: false
@@ -75,4 +84,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_09_055759) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "purchase_records", "items"
+  add_foreign_key "purchase_records", "users"
 end

--- a/spec/factories/purchase_records.rb
+++ b/spec/factories/purchase_records.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :purchase_record do
-    
   end
 end

--- a/spec/factories/purchase_records.rb
+++ b/spec/factories/purchase_records.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :purchase_record do
+    
+  end
+end

--- a/spec/models/purchase_record_spec.rb
+++ b/spec/models/purchase_record_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PurchaseRecord, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What
・トップ画面に商品一覧が表示される記述を追加
・purchase_recordモデルの追加 

# Why
商品一覧表示機能を実装するため

# Gyazoの動画
商品のデータがない場合は、ダミー商品が表示されている動画
（DBから出品データを削除し、ページ更新しています)
https://gyazo.com/3679383e8cda7a00099045c33ba52404

 商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/f9e704c51ee7e0a94bb7d8a0b7671003